### PR TITLE
Split workflows, trigger build on tag push and tag on PR merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,42 +1,15 @@
 name: Build Caddy with Cloudflare DNS
 
 on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - main
+  push:
+    tags:
+      - 'v*'
 
 jobs:
-  bump-version-tag:
-    if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Get Version from Dockerfile
-        id: getversion
-        run: |
-          VERSION="v$(awk -F'[:-]' 'NR==1{print $2}' Dockerfile)"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-      - name: Create Tag
-        uses: actions/github-script@v9
-        with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/${{ steps.getversion.outputs.version }}',
-              sha: context.sha
-            })
-
   build-caddy-with-cloudflare:
     runs-on: ubuntu-latest
-    needs: bump-version-tag
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-tags: true
-          fetch-depth: 0
 
       - name: Docker meta
         id: meta
@@ -48,7 +21,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Login to image repository
         uses: docker/login-action@v4

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,30 @@
+name: Create Version Tag
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  bump-version-tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Get Version from Dockerfile
+        id: getversion
+        run: |
+          VERSION="v$(awk -F'[:-]' 'NR==1{print $2}' Dockerfile)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Create Tag
+        uses: actions/github-script@v9
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ steps.getversion.outputs.version }}',
+              sha: context.sha
+            })


### PR DESCRIPTION
Hopefully fixes automatic semver tagging.

Splits the two jobs into separate workflows. The tag job fires on a PR merge, parses the tag from the Dockerfile, and tags the merge commit with it. When that happens, it *should* trigger the build job, which builds, tags, and pushes the docker images to GHCR. But it can only be tested on PR merges so we'll do it with this one.