### PR TITLE
fix: use PAT to trigger build on tag push

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Create Tag
         uses: actions/github-script@v9
         with:
+          github-token: ${{ secrets.RELEASE_TOKEN }}
           script: |
             github.rest.git.createRef({
               owner: context.repo.owner,


### PR DESCRIPTION
Using a fine-grained PAT instead of the default token because Github doesn't trigger workflows on pushes from `GITHUB_TOKEN`.